### PR TITLE
fix: defer drop-position setState to avoid mutation during layout pass

### DIFF
--- a/lib/src/internal/widgets/docking_item_widget.dart
+++ b/lib/src/internal/widgets/docking_item_widget.dart
@@ -10,6 +10,7 @@ import 'package:docking/src/on_item_selection.dart';
 import 'package:docking/src/theme/docking_theme.dart';
 import 'package:docking/src/theme/docking_theme_data.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter/scheduler.dart';
 import 'package:meta/meta.dart';
 import 'package:tabbed_view/tabbed_view.dart';
 
@@ -139,8 +140,12 @@ class DockingItemWidgetState extends State<DockingItemWidget>
 
   void _updateActiveDropPosition(DropPosition? dropPosition) {
     if (_activeDropPosition != dropPosition) {
-      setState(() {
-        _activeDropPosition = dropPosition;
+      SchedulerBinding.instance.addPostFrameCallback((_) {
+        if (mounted) {
+          setState(() {
+            _activeDropPosition = dropPosition;
+          });
+        }
       });
     }
   }

--- a/lib/src/internal/widgets/docking_tabs_widget.dart
+++ b/lib/src/internal/widgets/docking_tabs_widget.dart
@@ -12,6 +12,7 @@ import 'package:docking/src/on_item_selection.dart';
 import 'package:docking/src/theme/docking_theme.dart';
 import 'package:docking/src/theme/docking_theme_data.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter/scheduler.dart';
 import 'package:tabbed_view/tabbed_view.dart';
 
 /// Represents a widget for [DockingTabs].
@@ -129,8 +130,12 @@ class DockingTabsWidgetState extends State<DockingTabsWidget>
 
   void _updateActiveDropPosition(DropPosition? dropPosition) {
     if (_activeDropPosition != dropPosition) {
-      setState(() {
-        _activeDropPosition = dropPosition;
+      SchedulerBinding.instance.addPostFrameCallback((_) {
+        if (mounted) {
+          setState(() {
+            _activeDropPosition = dropPosition;
+          });
+        }
       });
     }
   }


### PR DESCRIPTION
## Problem

When dragging a tab over a split-view pane, `onWillAcceptWithDetails` on the
`DragTarget` inside `ContentWrapperBase`'s `LayoutBuilder` fires synchronously
during Flutter's layout phase. The listener callback immediately calls `setState()`,
which marks a sibling pane's RenderObject as needing layout while the current
`LayoutBuilder` is still in `performLayout`. Flutter asserts in debug mode:

> A _RenderLayoutBuilder was mutated in _RenderLayoutBuilder.performLayout.

Reproducible with two panes in split view — drag any tab a couple times (fast): sometimes it fires.

## Fix

Wrap the `setState` in `SchedulerBinding.instance.addPostFrameCallback` in both
`DockingItemWidgetState` and `DockingTabsWidgetState`. This defers the state
update until after the current frame's layout and paint are complete.
