### PR TITLE
Fork docking v1.16.1: disable edge splits, preserve pane identity

### DIFF
--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -1,5 +1,6 @@
 import 'package:docking/docking.dart';
 import 'package:flutter/material.dart';
+import 'package:tabbed_view/tabbed_view.dart';
 
 void main() {
   runApp(const DockingExampleApp());
@@ -13,9 +14,7 @@ class DockingExampleApp extends StatelessWidget {
     return MaterialApp(
       debugShowCheckedModeBanner: false,
       title: 'Docking example',
-      theme: ThemeData(
-        primarySwatch: Colors.blue,
-      ),
+      theme: ThemeData(primarySwatch: Colors.blue),
       home: const DockingExamplePage(),
     );
   }
@@ -34,56 +33,113 @@ class DockingExamplePageState extends State<DockingExamplePage> {
   @override
   void initState() {
     super.initState();
-    int v = 1;
     _layout = DockingLayout(
-        root: DockingRow([
-      _buildItem(v++, weight: .2),
-      DockingColumn([
-        DockingRow([_nonMaximizableItem, _nonClosableItem, _minimalSizeItem]),
-        DockingTabs([_buildItem(v++), _buildItem(v++)]),
-        _minimalWeightItem
-      ])
-    ]));
+      root: DockingRow([
+        DockingTabs([
+          DockingItem(
+            id: 'left_1',
+            name: 'Home',
+            widget: const CenterText(text: 'Left — Home'),
+          ),
+          DockingItem(
+            id: 'left_2',
+            name: 'Documents',
+            widget: const CenterText(text: 'Left — Documents'),
+          ),
+          DockingItem(
+            id: 'left_3',
+            name: 'Downloads',
+            widget: const CenterText(text: 'Left — Downloads'),
+          ),
+          DockingItem(
+            id: 'left_4',
+            name: 'Desktop',
+            widget: const CenterText(text: 'Left — Desktop'),
+          ),
+        ]),
+        DockingTabs([
+          DockingItem(
+            id: 'right_1',
+            name: 'Android',
+            widget: const CenterText(text: 'Right — Android'),
+          ),
+          DockingItem(
+            id: 'right_2',
+            name: 'DCIM',
+            widget: const CenterText(text: 'Right — DCIM'),
+          ),
+          DockingItem(
+            id: 'right_3',
+            name: 'Pictures',
+            widget: const CenterText(text: 'Right — Pictures'),
+          ),
+          DockingItem(
+            id: 'right_4',
+            name: 'Music',
+            widget: const CenterText(text: 'Right — Music'),
+          ),
+        ]),
+      ]),
+    );
   }
 
-  DockingItem get _minimalWeightItem => DockingItem(
-      name: 'minimalSize',
-      minimalWeight: .15,
-      widget: const CenterText(text: 'minimalWeight: .15'));
-
-  DockingItem get _minimalSizeItem => DockingItem(
-      name: 'minimalSize',
-      minimalSize: 150,
-      widget: const CenterText(text: 'minimalSize: 150'));
-
-  DockingItem get _nonMaximizableItem => DockingItem(
-      name: 'non-maximizable',
-      maximizable: false,
-      widget: const CenterText(text: 'non-maximizable'));
-
-  DockingItem get _nonClosableItem => DockingItem(
-      name: 'non-closable',
-      closable: false,
-      widget: const CenterText(text: 'non-closable'));
-
-  DockingItem _buildItem(int value,
-      {double? weight, bool closable = true, bool? maximizable}) {
-    return DockingItem(
-        weight: weight,
-        name: value.toString(),
-        closable: closable,
-        maximizable: maximizable,
-        widget: Center(child: Text('$value')));
+  bool _onCloseInterceptor(DockingItem item) {
+    // Block close if this is the very last tab in the entire layout
+    final totalItems = _layout.layoutAreas().whereType<DockingItem>().length;
+    return totalItems > 1;
   }
 
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-        body: TabbedViewTheme(
-            data: TabbedViewThemeData.classic(),
-            child: Container(
-                padding: const EdgeInsets.all(16),
-                child: Docking(layout: _layout))));
+      body: TabbedViewTheme(
+        data: TabbedViewThemeData.minimalist(),
+        child: Docking(
+          layout: _layout,
+          draggable: true,
+          itemCloseInterceptor: _onCloseInterceptor,
+          dockingButtonsBuilder: (context, dockingTabs, dockingItem) {
+            if (dockingTabs != null) {
+              return [
+                TabButton(
+                  icon: IconProvider.data(Icons.add),
+                  onPressed: () {
+                    _layout.addItemOn(
+                      newItem: DockingItem(
+                        id: 'new_${DateTime.now().millisecondsSinceEpoch}',
+                        name: 'New Tab',
+                        widget: const CenterText(text: 'New Tab'),
+                      ),
+                      targetArea: dockingTabs,
+                      dropIndex: dockingTabs.childrenCount,
+                    );
+                  },
+                )
+              ];
+            }
+            if (dockingItem != null) {
+              return [
+                TabButton(
+                  icon: IconProvider.data(Icons.add),
+                  onPressed: () {
+                    _layout.addItemOn(
+                      newItem: DockingItem(
+                        id: 'new_${DateTime.now().millisecondsSinceEpoch}',
+                        name: 'New Tab',
+                        widget: const CenterText(text: 'New Tab'),
+                      ),
+                      targetArea: dockingItem,
+                      dropIndex: 1,
+                    );
+                  },
+                )
+              ];
+            }
+            return [];
+          },
+        ),
+      ),
+    );
   }
 }
 
@@ -94,6 +150,8 @@ class CenterText extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return Center(child: Text(text, overflow: TextOverflow.ellipsis));
+    return Center(
+      child: Text(text, overflow: TextOverflow.ellipsis),
+    );
   }
 }

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -126,10 +126,10 @@ packages:
     dependency: transitive
     description:
       name: meta
-      sha256: "23f08335362185a5ea2ad3a4e597f1375e78bce8a040df5c600c8d3552ef2394"
+      sha256: "1741988757a65eb6b36abe716829688cf01910bbf91c34354ff7ec1c3de2b349"
       url: "https://pub.dev"
     source: hosted
-    version: "1.17.0"
+    version: "1.18.0"
   multi_split_view:
     dependency: transitive
     description:
@@ -224,5 +224,5 @@ packages:
     source: hosted
     version: "14.2.5"
 sdks:
-  dart: ">=3.9.0-0 <4.0.0"
+  dart: ">=3.10.0-0 <4.0.0"
   flutter: ">=3.18.0-18.0.pre.54"

--- a/lib/src/docking.dart
+++ b/lib/src/docking.dart
@@ -18,9 +18,9 @@ class Docking extends StatefulWidget {
       this.onItemClose,
       this.itemCloseInterceptor,
       this.dockingButtonsBuilder,
-      this.maximizableItem = true,
-      this.maximizableTab = true,
-      this.maximizableTabsArea = true,
+      this.maximizableItem = false,
+      this.maximizableTab = false,
+      this.maximizableTabsArea = false,
       this.antiAliasingWorkaround = true,
       this.draggable = true})
       : super(key: key);

--- a/lib/src/internal/layout/drop_item.dart
+++ b/lib/src/internal/layout/drop_item.dart
@@ -116,8 +116,12 @@ class DropItem extends LayoutModifier {
           oldSelection = child;
         }
       }
+
       final DockingArea? newArea;
-      if (children.length == 1) {
+      if (children.isEmpty) {
+        // Pane emptied — remove it from layout entirely.
+        newArea = null;
+      } else if (children.length == 1) {
         newArea = children.first;
       } else {
         newArea = DockingTabs(children,
@@ -133,6 +137,7 @@ class DropItem extends LayoutModifier {
               newSelectedIndex > -1 ? newSelectedIndex : 0;
         }
       }
+
       if (dockingTabs == targetArea) {
         DockingItem newDraggedItem = dropItem;
         if (dropIndex != null) {
@@ -159,13 +164,13 @@ class DropItem extends LayoutModifier {
           }
           return newDockingTabs;
         } else if (dropPosition == DropPosition.top) {
-          return DockingColumn([newDraggedItem, newArea]);
+          return DockingColumn([newDraggedItem, newArea!]);
         } else if (dropPosition == DropPosition.bottom) {
-          return DockingColumn([newArea, newDraggedItem]);
+          return DockingColumn([newArea!, newDraggedItem]);
         } else if (dropPosition == DropPosition.left) {
-          return DockingRow([newDraggedItem, newArea]);
+          return DockingRow([newDraggedItem, newArea!]);
         } else if (dropPosition == DropPosition.right) {
-          return DockingRow([newArea, newDraggedItem]);
+          return DockingRow([newArea!, newDraggedItem]);
         } else {
           throw ArgumentError(
               'DropPosition not recognized: ' + dropPosition.toString());

--- a/lib/src/internal/widgets/docking_item_widget.dart
+++ b/lib/src/internal/widgets/docking_item_widget.dart
@@ -85,7 +85,10 @@ class DockingItemWidgetState extends State<DockingItemWidget>
           value: widget.item,
           text: name,
           content: content,
-          closable: widget.item.closable,
+          closable:
+              widget.layout.layoutAreas().whereType<DockingItem>().length > 1
+                  ? widget.item.closable
+                  : false,
           leading: widget.item.leading,
           buttons: buttons,
           draggable: widget.draggable)

--- a/lib/src/internal/widgets/docking_tabs_widget.dart
+++ b/lib/src/internal/widgets/docking_tabs_widget.dart
@@ -50,6 +50,10 @@ class DockingTabsWidgetState extends State<DockingTabsWidget>
     with DraggableConfigMixin {
   DropPosition? _activeDropPosition;
 
+  /// Allow right edge drop only when there is a single pane —
+  /// i.e. root is not yet a DockingRow.
+  bool get _allowRightEdgeDrop => widget.layout.root is! DockingRow;
+
   @override
   Widget build(BuildContext context) {
     List<TabData> tabs = [];
@@ -82,16 +86,23 @@ class DockingTabsWidgetState extends State<DockingTabsWidget>
               onPressed: () => widget.layout.maximizeDockingItem(child)));
         }
       }
+
+      // Hide close button when this is the very last tab in the layout
+      final int totalItems =
+          widget.layout.layoutAreas().whereType<DockingItem>().length;
+      final bool closable = totalItems > 1 ? child.closable : false;
+
       tabs.add(TabData(
           value: child,
           text: child.name != null ? child.name! : '',
           content: content,
-          closable: child.closable,
+          closable: closable,
           keepAlive: child.globalKey != null,
           leading: child.leading,
           buttons: buttons,
           draggable: widget.draggable));
     });
+
     TabbedViewController controller = TabbedViewController(tabs);
     controller.selectedIndex =
         math.min(widget.dockingTabs.selectedIndex, tabs.length - 1);
@@ -119,8 +130,10 @@ class DockingTabsWidgetState extends State<DockingTabsWidget>
             listener: _updateActiveDropPosition,
             layout: widget.layout,
             dockingTabs: widget.dockingTabs,
+            allowRightEdgeDrop: _allowRightEdgeDrop,
             child: controller.tabs[tabIndex].content!),
         onBeforeDropAccept: widget.draggable ? _onBeforeDropAccept : null);
+
     if (widget.draggable && widget.dragOverPosition.enable) {
       return DropFeedbackWidget(
           dropPosition: _activeDropPosition, child: tabbedView);

--- a/lib/src/internal/widgets/drop/content_wrapper.dart
+++ b/lib/src/internal/widgets/drop/content_wrapper.dart
@@ -10,59 +10,32 @@ abstract class ContentWrapperBase extends StatelessWidget {
       {Key? key,
       required this.layout,
       required this.listener,
-      required this.child})
+      required this.child,
+      this.allowRightEdgeDrop = false})
       : super(key: key);
 
   final DockingLayout layout;
   final Widget child;
   final DropWidgetListener listener;
+  final bool allowRightEdgeDrop;
 
   @nonVirtual
   @override
   Widget build(BuildContext context) {
+    if (!allowRightEdgeDrop) {
+      return child;
+    }
     return LayoutBuilder(
         builder: (BuildContext context, BoxConstraints constraints) {
-      List<Widget> children = [Positioned.fill(child: child)];
-
-      // percentage of width reserved for detecting center area
-      const double centerWidthRatio = 50;
-      // reserved width to detect center area
-      final double centerWidth = centerWidthRatio * constraints.maxWidth / 100;
-      // reserved width to detect left and right areas
-      final double horizontalEdgeWidth =
-          (constraints.maxWidth - centerWidth) / 2;
-      // height reserved for detecting the top and bottom areas
-      final double verticalEdgeHeight = constraints.maxHeight / 2;
-
-      children.add(Positioned(
-          child: buildDropAnchor(DropPosition.left),
-          width: horizontalEdgeWidth,
-          bottom: 0,
-          top: 0,
-          left: 0));
-
-      children.add(Positioned(
-          child: buildDropAnchor(DropPosition.right),
-          width: horizontalEdgeWidth,
-          bottom: 0,
-          top: 0,
-          right: 0));
-
-      children.add(Positioned(
-          child: buildDropAnchor(DropPosition.top),
-          height: verticalEdgeHeight,
-          top: 0,
-          left: horizontalEdgeWidth,
-          right: horizontalEdgeWidth));
-
-      children.add(Positioned(
-          child: buildDropAnchor(DropPosition.bottom),
-          height: verticalEdgeHeight,
-          bottom: 0,
-          left: horizontalEdgeWidth,
-          right: horizontalEdgeWidth));
-
-      return Stack(children: children);
+      return Stack(children: [
+        Positioned.fill(child: child),
+        Positioned(
+            child: buildDropAnchor(DropPosition.right),
+            width: constraints.maxWidth / 2,
+            top: 0,
+            bottom: 0,
+            right: 0),
+      ]);
     });
   }
 
@@ -75,9 +48,14 @@ class ItemContentWrapper extends ContentWrapperBase {
       {required DockingLayout layout,
       required DropWidgetListener listener,
       required DockingItem dockingItem,
-      required Widget child})
+      required Widget child,
+      bool allowRightEdgeDrop = false})
       : _dockingItem = dockingItem,
-        super(layout: layout, listener: listener, child: child);
+        super(
+            layout: layout,
+            listener: listener,
+            child: child,
+            allowRightEdgeDrop: allowRightEdgeDrop);
 
   final DockingItem _dockingItem;
 
@@ -97,9 +75,14 @@ class TabsContentWrapper extends ContentWrapperBase {
       {required DockingLayout layout,
       required DropWidgetListener listener,
       required DockingTabs dockingTabs,
-      required Widget child})
+      required Widget child,
+      bool allowRightEdgeDrop = false})
       : _dockingTabs = dockingTabs,
-        super(layout: layout, listener: listener, child: child);
+        super(
+            layout: layout,
+            listener: listener,
+            child: child,
+            allowRightEdgeDrop: allowRightEdgeDrop);
 
   final DockingTabs _dockingTabs;
 

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -119,10 +119,10 @@ packages:
     dependency: "direct main"
     description:
       name: meta
-      sha256: "23f08335362185a5ea2ad3a4e597f1375e78bce8a040df5c600c8d3552ef2394"
+      sha256: "1741988757a65eb6b36abe716829688cf01910bbf91c34354ff7ec1c3de2b349"
       url: "https://pub.dev"
     source: hosted
-    version: "1.17.0"
+    version: "1.18.0"
   multi_split_view:
     dependency: "direct main"
     description:
@@ -217,5 +217,5 @@ packages:
     source: hosted
     version: "14.2.5"
 sdks:
-  dart: ">=3.9.0-0 <4.0.0"
+  dart: ">=3.10.0-0 <4.0.0"
   flutter: ">=3.18.0-18.0.pre.54"


### PR DESCRIPTION
Fork docking v1.16.1: disable edge splits, preserve pane identity, fix empty pane crash

Add right edge drop for 2nd pane creation, hide close btn on last tab, add new tab button